### PR TITLE
build: upgrade Compact CLI to 0.5.0 and compiler to 0.30.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  COMPACT_CLI_VERSION: "0.4.0"
+  COMPACT_CLI_VERSION: "0.5.0"
 
 jobs:
   lint:
@@ -69,6 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           compact --version
+          compact update 0.30.0
           compact update 0.29.0
           compact update 0.28.0
       - run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ WORKDIR /opt/oz-compact
 RUN npm install -g --force corepack && corepack enable && corepack prepare
 # Install all workspace dependencies (including devDeps needed for build)
 RUN yarn install
+# Upgrade compact-runtime to match what the latest compiler (0.30.0) emits.
+# The OZ repo pins 0.14.0 but compiler 0.30.0 generates bindings expecting 0.15.0.
+RUN yarn up @midnight-ntwrk/compact-runtime@0.15.0
 # Build the simulator package (tsc -p .)
 WORKDIR /opt/oz-compact/packages/simulator
 RUN yarn build
@@ -62,8 +65,8 @@ WORKDIR /app
 ENV HOME="/root"
 RUN mkdir -p /root/.compact/bin
 
-# Download Compact CLI tool (compact-v0.4.0)
-RUN curl -fsSL https://github.com/midnightntwrk/compact/releases/download/compact-v0.4.0/compact-x86_64-unknown-linux-musl.tar.xz \
+# Download Compact CLI tool (compact-v0.5.0)
+RUN curl -fsSL https://github.com/midnightntwrk/compact/releases/download/compact-v0.5.0/compact-x86_64-unknown-linux-musl.tar.xz \
        -o /tmp/compact.tar.xz \
     && mkdir -p /tmp/compact-extract \
     && tar -xJf /tmp/compact.tar.xz -C /tmp/compact-extract \
@@ -78,7 +81,8 @@ ENV PATH="/root/.compact/bin:$PATH"
 ARG DEFAULT_COMPILER=latest
 
 # Pre-install all available compiler versions
-RUN compact update 0.29.0 \
+RUN compact update 0.30.0 \
+    && compact update 0.29.0 \
     && compact update 0.28.0 \
     && compact update 0.26.0 \
     && compact update 0.25.0 \
@@ -86,11 +90,11 @@ RUN compact update 0.29.0 \
     && compact update 0.23.0 \
     && compact update 0.22.0
 
-# Set the CLI default — explicit version or latest (0.29.0)
+# Set the CLI default — explicit version or latest (0.30.0)
 RUN if [ "$DEFAULT_COMPILER" != "latest" ]; then \
       compact update "$DEFAULT_COMPILER"; \
     else \
-      compact update 0.29.0; \
+      compact update 0.30.0; \
     fi
 
 # Verify installation

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ curl http://localhost:8080/compile \
 {
   "success": true,
   "results": [
-    {"version": "0.29.0", "requestedVersion": "latest", "success": true, "output": "Compilation successful", "executionTime": 3100},
+    {"version": "0.30.0", "requestedVersion": "latest", "success": true, "output": "Compilation successful", "executionTime": 3100},
     {"version": "0.26.0", "requestedVersion": "0.26.0", "success": false, "errors": [{"message": "language version 0.18.0 mismatch", "severity": "error"}]}
   ]
 }
@@ -215,8 +215,8 @@ curl http://localhost:8080/analyze \
     "success": true,
     "diagnostics": [],
     "executionTime": 3200,
-    "compilerVersion": "0.29.0",
-    "languageVersion": "0.21.0"
+    "compilerVersion": "0.30.0",
+    "languageVersion": "0.22.0"
   }
 }
 ```
@@ -261,8 +261,9 @@ curl http://localhost:8080/versions
 **Response:**
 ```json
 {
-  "default": "0.29.0",
+  "default": "0.30.0",
   "installed": [
+    {"version": "0.30.0", "languageVersion": "0.22.0"},
     {"version": "0.29.0", "languageVersion": "0.21.0"},
     {"version": "0.28.0", "languageVersion": "0.20.0"},
     {"version": "0.26.0", "languageVersion": "0.18.0"},
@@ -286,8 +287,8 @@ curl http://localhost:8080/health
 ```json
 {
   "status": "healthy",
-  "compactCli": {"installed": true, "version": "0.4.0"},
-  "defaultVersion": {"configured": "latest", "resolved": "0.29.0", "valid": true},
+  "compactCli": {"installed": true, "version": "0.5.0"},
+  "defaultVersion": {"configured": "latest", "resolved": "0.30.0", "valid": true},
   "timestamp": "2026-03-09T14:00:00.000Z"
 }
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -27,12 +27,12 @@ When a user submits code:
 The Dockerfile installs the Compact CLI and pre-installs multiple compiler versions:
 
 ### 1. Compact CLI (`compact`)
-- Release: `compact-v0.4.0`
+- Release: `compact-v0.5.0`
 - Purpose: Toolchain manager that handles compiler version selection and subcommands
 
 ### 2. Compiler Versions
 Pre-installed via `compact update <version>` during Docker build:
-- 0.29.0, 0.28.0, 0.26.0, 0.25.0, 0.24.0, 0.23.0, 0.22.0
+- 0.30.0, 0.29.0, 0.28.0, 0.26.0, 0.25.0, 0.24.0, 0.23.0, 0.22.0
 
 The CLI's `compact update` command downloads and installs compiler versions. At runtime, version selection works as follows:
 - **Compilation**: `compact compile +VERSION --skip-zk <source> <output>`
@@ -75,7 +75,7 @@ To add a new compiler version:
 All POST endpoints that compile code accept version selection:
 - `"latest"` -- newest installed compiler
 - `"detect"` -- parse `pragma language_version` from source to find the best compiler match, fall back to default
-- Specific version (e.g. `"0.29.0"`) -- must be installed
+- Specific version (e.g. `"0.30.0"`) -- must be installed
 - `versions` array -- run the operation against multiple compiler versions in parallel
 
 ### Compile Options

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -227,13 +227,13 @@ pause
 banner "7. Compile — Multiple Versions"
 
 describe "Pass multiple versions to compile against all of them in parallel.
-Results are returned per version. 0.29.0 should succeed (language 0.21.0 satisfies
+Results are returned per version. 0.30.0 should succeed (language 0.22.0 satisfies
 pragma >= 0.21), while older versions show expected mismatches.
 Using the same counter.compact code from above."
 
-CMD="curl -s $API/compile -H 'Content-Type: application/json' -d '{\"code\": $CODE, \"versions\": [\"0.29.0\", \"0.26.0\", \"0.24.0\"]}'"
+CMD="curl -s $API/compile -H 'Content-Type: application/json' -d '{\"code\": $CODE, \"versions\": [\"0.30.0\", \"0.29.0\", \"0.26.0\"]}'"
 
-show_request "POST /compile  (counter.compact, versions 0.29.0 + 0.26.0 + 0.24.0)"
+show_request "POST /compile  (counter.compact, versions 0.30.0 + 0.29.0 + 0.26.0)"
 pause
 send_request "$CMD"
 pause
@@ -484,9 +484,9 @@ banner "20. Analyze — Deep Mode (Multiple Versions)"
 describe "Deep analysis across multiple compiler versions shows which versions
 successfully compile the code. Each version gets its own compilation result."
 
-CMD="curl -s $API/analyze -H 'Content-Type: application/json' -d '{\"code\": $CODE, \"mode\": \"deep\", \"versions\": [\"0.29.0\", \"0.26.0\", \"0.24.0\"]}'"
+CMD="curl -s $API/analyze -H 'Content-Type: application/json' -d '{\"code\": $CODE, \"mode\": \"deep\", \"versions\": [\"0.30.0\", \"0.29.0\", \"0.26.0\"]}'"
 
-show_request "POST /analyze  (counter.compact, deep mode, versions 0.29.0 + 0.26.0 + 0.24.0)"
+show_request "POST /analyze  (counter.compact, deep mode, versions 0.30.0 + 0.29.0 + 0.26.0)"
 pause
 send_request "$CMD"
 pause


### PR DESCRIPTION
- Compact CLI 0.4.0 → 0.5.0 (Dockerfile, CI workflow)
- Add compiler 0.30.0 (language version 0.22.0) to pre-installed set
- Upgrade compact-runtime 0.14.0 → 0.15.0 in OZ simulator build to match bindings emitted by compiler 0.30.0
- Update demo script multi-version examples to use 0.30.0
- Update README and backend README version references