### PR TITLE
Fix: add pre-parse HTTP body size limits for JSON endpoints

### DIFF
--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -13,6 +13,7 @@ export interface Config {
   cacheTtl: number;
   maxVersionsPerRequest: number;
   maxCodeSize: number;
+  maxJsonBodySize: number;
   archiveRateLimit: number;
   archiveRateWindow: number;
   trustCloudflare: boolean;
@@ -41,6 +42,7 @@ export function getConfig(): Config {
     cacheTtl: parseInt(process.env.CACHE_TTL || "2592000000", 10), // 30 days
     maxVersionsPerRequest: parseInt(process.env.MAX_VERSIONS_PER_REQUEST || "10", 10),
     maxCodeSize: parseInt(process.env.MAX_CODE_SIZE || String(100 * 1024), 10),
+    maxJsonBodySize: parseInt(process.env.MAX_JSON_BODY_SIZE || String(512 * 1024), 10),
     archiveRateLimit: parseInt(process.env.ARCHIVE_RATE_LIMIT || "10", 10),
     archiveRateWindow: parseInt(process.env.ARCHIVE_RATE_WINDOW || "60000", 10),
     trustCloudflare: process.env.TRUST_CLOUDFLARE === "true",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,7 +12,7 @@ import { visualizeRoutes } from "./routes/visualize.js";
 import { cachedResponseRoutes } from "./routes/cached-response.js";
 import { simulateRoutes } from "./routes/simulate.js";
 import { proveRoutes } from "./routes/prove.js";
-import { validateRequestBody } from "./middleware.js";
+import { createJsonBodyLimit, validateRequestBody } from "./middleware.js";
 
 import { healthRoutes, warmVersionsCache } from "./routes/health.js";
 import { getFileCache } from "./cache.js";
@@ -30,6 +30,7 @@ app.use(
   }),
 );
 
+app.use("*", createJsonBodyLimit());
 app.use("*", validateRequestBody);
 
 // Mount routes

--- a/backend/src/middleware.ts
+++ b/backend/src/middleware.ts
@@ -1,6 +1,35 @@
 import type { Context, Next } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { getConfig } from "./config.js";
 import { resolveRequestedVersion } from "./version-manager.js";
+
+/**
+ * Hono middleware that enforces an HTTP body size limit on JSON POST endpoints.
+ * Rejects oversized requests with 413 before the body is parsed into memory.
+ * Skips the /compile/archive multipart endpoint (which has its own limit).
+ */
+export function createJsonBodyLimit() {
+  const config = getConfig();
+  const limiter = bodyLimit({
+    maxSize: config.maxJsonBodySize,
+    onError: (c) =>
+      c.json(
+        {
+          success: false,
+          error: "Payload too large",
+          message: `Request body must be less than ${String(Math.floor(config.maxJsonBodySize / 1024))}KB`,
+        },
+        413,
+      ),
+  });
+
+  return (c: Context, next: Next) => {
+    if (c.req.path === "/compile/archive") {
+      return next();
+    }
+    return limiter(c as never, next);
+  };
+}
 
 /**
  * Hono middleware that validates request bodies for POST endpoints.

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { Hono } from "hono";
-import { runMultiVersion, validateRequestBody } from "../backend/src/middleware.js";
+import {
+  runMultiVersion,
+  validateRequestBody,
+  createJsonBodyLimit,
+} from "../backend/src/middleware.js";
 
 describe("runMultiVersion", () => {
   it("executes operation for each resolved version", async () => {
@@ -96,6 +100,100 @@ describe("validateRequestBody", () => {
   });
 
   it("passes through GET requests without checking body", async () => {
+    const app = createApp();
+    const res = await app.request("/health", { method: "GET" });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("createJsonBodyLimit", () => {
+  function createApp() {
+    const app = new Hono();
+    app.use("*", createJsonBodyLimit());
+    app.post("/compile", async (c) => {
+      await c.req.json();
+      return c.json({ success: true });
+    });
+    app.post("/prove", async (c) => {
+      await c.req.json();
+      return c.json({ success: true });
+    });
+    app.post("/simulate/deploy", async (c) => {
+      await c.req.json();
+      return c.json({ success: true });
+    });
+    app.post("/compile/archive", (c) => {
+      // Archive endpoint should bypass JSON body limit
+      return c.json({ success: true });
+    });
+    app.get("/health", (c) => c.json({ status: "ok" }));
+    return app;
+  }
+
+  it("rejects oversized JSON body on /compile with 413", async () => {
+    const app = createApp();
+    const oversizedBody = JSON.stringify({ code: "x".repeat(600 * 1024) });
+    const res = await app.request("/compile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: oversizedBody,
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Payload too large");
+  });
+
+  it("rejects oversized JSON body on /prove with 413", async () => {
+    const app = createApp();
+    const oversizedBody = JSON.stringify({ code: "x".repeat(600 * 1024) });
+    const res = await app.request("/prove", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: oversizedBody,
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Payload too large");
+  });
+
+  it("rejects oversized JSON body on /simulate/deploy with 413", async () => {
+    const app = createApp();
+    const oversizedBody = JSON.stringify({ code: "x".repeat(600 * 1024) });
+    const res = await app.request("/simulate/deploy", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: oversizedBody,
+    });
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Payload too large");
+  });
+
+  it("allows requests under the size limit", async () => {
+    const app = createApp();
+    const res = await app.request("/compile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: "small code" }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("skips /compile/archive endpoint", async () => {
+    const app = createApp();
+    const res = await app.request("/compile/archive", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "x".repeat(600 * 1024),
+    });
+    // Should reach the handler (200), not be blocked by JSON body limit
+    expect(res.status).toBe(200);
+  });
+
+  it("passes through GET requests", async () => {
     const app = createApp();
     const res = await app.request("/health", { method: "GET" });
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

- Adds HTTP-level body size limit (512KB, configurable via `MAX_JSON_BODY_SIZE`) enforced **before** JSON parsing occurs, preventing memory-exhaustion DoS
- Uses Hono's `bodyLimit` middleware applied globally to all POST routes except `/compile/archive` (which retains its own 1MB multipart limit)
- Adds `maxJsonBodySize` config field to `Config` interface
- Oversized requests are rejected with `413 Payload Too Large` before any body buffering

## Test plan

- [x] Tests cover oversized body rejection on `/compile` (413)
- [x] Tests cover oversized body rejection on `/prove` (413)
- [x] Tests cover oversized body rejection on `/simulate/deploy` (413)
- [x] Tests verify requests under the limit pass through (200)
- [x] Tests verify `/compile/archive` bypass works correctly
- [x] Tests verify GET requests are unaffected
- [x] Full test suite passes (349/349)
- [x] Lint, format, typecheck, audit all clean

Closes #31

Generated with [Claude Code](https://claude.com/claude-code)