### PR TITLE
Fix: reduce max versions per request from 10 to 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ All settings are controlled via environment variables:
 | `CACHE_MAX_SIZE` | `1000` | Max cache entries |
 | `CACHE_TTL` | `3600000` | Cache TTL in ms (1 hour) |
 | `MAX_CODE_SIZE` | `102400` | Max code size in bytes (100 KB) |
-| `MAX_VERSIONS_PER_REQUEST` | `10` | Max versions in a multi-version request |
+| `MAX_VERSIONS_PER_REQUEST` | `3` | Max versions in a multi-version request |
 | `TRUST_PROXY` | `false` | Trust `X-Forwarded-For` / `X-Real-IP` headers for client IP |
 | `TRUST_CLOUDFLARE` | `false` | Trust `CF-Connecting-IP` header for client IP |
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -181,7 +181,7 @@ backend/src/
 | `CACHE_MAX_DISK_MB` | `800` | Max cache disk usage in MB |
 | `CACHE_MAX_ENTRIES` | `50000` | Max cached entries |
 | `CACHE_TTL` | `2592000000` | Cache entry TTL in ms (30 days) |
-| `MAX_VERSIONS_PER_REQUEST` | `10` | Max versions in a multi-version request |
+| `MAX_VERSIONS_PER_REQUEST` | `3` | Max versions in a multi-version request |
 | `MAX_CODE_SIZE` | `102400` | Max code size in bytes (100 KB) |
 | `TRUST_PROXY` | `false` | Trust `X-Forwarded-For` / `X-Real-IP` headers for client IP |
 | `TRUST_CLOUDFLARE` | `false` | Trust `CF-Connecting-IP` header for client IP |

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -39,7 +39,7 @@ export function getConfig(): Config {
     cacheMaxDiskMb: parseInt(process.env.CACHE_MAX_DISK_MB || "800", 10),
     cacheMaxEntries: parseInt(process.env.CACHE_MAX_ENTRIES || "50000", 10),
     cacheTtl: parseInt(process.env.CACHE_TTL || "2592000000", 10), // 30 days
-    maxVersionsPerRequest: parseInt(process.env.MAX_VERSIONS_PER_REQUEST || "10", 10),
+    maxVersionsPerRequest: parseInt(process.env.MAX_VERSIONS_PER_REQUEST || "3", 10),
     maxCodeSize: parseInt(process.env.MAX_CODE_SIZE || String(100 * 1024), 10),
     archiveRateLimit: parseInt(process.env.ARCHIVE_RATE_LIMIT || "10", 10),
     archiveRateWindow: parseInt(process.env.ARCHIVE_RATE_WINDOW || "60000", 10),

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -60,9 +60,9 @@ describe("validateRequestBody", () => {
     expect(body.error).toBe("Code too large");
   });
 
-  it("rejects versions array exceeding limit", async () => {
+  it("rejects versions array exceeding limit of 3", async () => {
     const app = createApp();
-    const versions = Array.from({ length: 15 }, (_, i) => `0.${String(i)}.0`);
+    const versions = ["0.28.0", "0.29.0", "0.30.0", "0.26.0"];
     const res = await app.request("/compile", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -71,6 +71,18 @@ describe("validateRequestBody", () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body.error).toBe("Too many versions");
+    expect(body.message).toBe("Maximum 3 versions per request");
+  });
+
+  it("allows exactly 3 versions", async () => {
+    const app = createApp();
+    const versions = ["0.28.0", "0.29.0", "0.30.0"];
+    const res = await app.request("/compile", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ code: "test", versions }),
+    });
+    expect(res.status).toBe(200);
   });
 
   it("rejects oversized 'before' in /diff", async () => {


### PR DESCRIPTION
## Summary

- Reduces default `MAX_VERSIONS_PER_REQUEST` from 10 to 3 to prevent user-triggerable OOM on the 1024MB Fly.io VM
- Each compiler process uses ~180MB; 3 concurrent = ~540MB, leaving ~480MB headroom for Node.js and I/O
- Updates documentation in both README files
- Adds boundary tests: rejects 4 versions, allows exactly 3

## Test plan

- [x] Requests with 4+ versions rejected with `400` and clear error message
- [x] Requests with exactly 3 versions pass through
- [x] Error message reflects dynamic config value ("Maximum 3 versions per request")
- [x] Full test suite passes (344/344)
- [x] Lint, format, typecheck, audit all clean
- [x] README.md and backend/README.md updated

Closes #32

Generated with [Claude Code](https://claude.com/claude-code)