### PR TITLE
Fix: align docker-compose config with application runtime contract

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,17 @@ services:
       - PORT=8080
       - DEFAULT_COMPILER_VERSION=${DEFAULT_COMPILER_VERSION:-latest}
       - CACHE_ENABLED=${CACHE_ENABLED:-true}
-      - CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-1000}
+      - CACHE_DIR=/data/cache
+      - CACHE_MAX_DISK_MB=${CACHE_MAX_DISK_MB:-800}
+      - CACHE_MAX_ENTRIES=${CACHE_MAX_ENTRIES:-50000}
+      - CACHE_TTL=${CACHE_TTL:-2592000000}
+      - TEMP_DIR=/tmp/compact-playground
       - RATE_LIMIT=${RATE_LIMIT:-20}
+      - RATE_WINDOW=${RATE_WINDOW:-60000}
+      - ARCHIVE_RATE_LIMIT=${ARCHIVE_RATE_LIMIT:-10}
+      - ARCHIVE_RATE_WINDOW=${ARCHIVE_RATE_WINDOW:-60000}
+    volumes:
+      - cache_data:/data/cache
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
@@ -16,3 +25,6 @@ services:
       start_period: 30s
       retries: 3
     restart: unless-stopped
+
+volumes:
+  cache_data:


### PR DESCRIPTION
## Summary

- Removed phantom `CACHE_MAX_SIZE` env var (not consumed by the app)
- Added correct cache vars: `CACHE_DIR`, `CACHE_MAX_DISK_MB`, `CACHE_MAX_ENTRIES`, `CACHE_TTL`
- Added `TEMP_DIR`, `RATE_WINDOW`, `ARCHIVE_RATE_LIMIT`, `ARCHIVE_RATE_WINDOW`
- Added named volume `cache_data` mounted to `/data/cache` for cache persistence
- All defaults verified consistent across `config.ts`, `Dockerfile`, and `docker-compose.yml`

## Test plan

- [x] `docker compose config --quiet` validates cleanly
- [x] All env var names match `getConfig()` in `backend/src/config.ts`
- [x] All defaults match the `Dockerfile` (lines 122-132)
- [x] Named volume correctly declared and mounted
- [x] Full test suite passes (343/343)
- [x] All pre-push checks clean (lint, format, typecheck, audit)

Closes #36

Generated with [Claude Code](https://claude.com/claude-code)