### PR TITLE
Fix: add startup validation for critical runtime dependencies

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import { cachedResponseRoutes } from "./routes/cached-response.js";
 import { simulateRoutes } from "./routes/simulate.js";
 import { proveRoutes } from "./routes/prove.js";
 import { createJsonBodyLimit, validateRequestBody } from "./middleware.js";
+import { validateStartup } from "./startup.js";
 import { healthRoutes, warmVersionsCache } from "./routes/health.js";
 import { getFileCache } from "./cache.js";
 
@@ -86,6 +87,16 @@ console.log(`
 ║           Starting on port ${String(port)}                    ║
 ╚═══════════════════════════════════════════════════╝
 `);
+
+// Validate critical runtime dependencies before accepting traffic
+const startupCheck = await validateStartup();
+if (!startupCheck.ok) {
+  for (const error of startupCheck.errors) {
+    console.error(`STARTUP ERROR: ${error}`);
+  }
+  process.exit(1);
+}
+console.log("Startup validation passed");
 
 // Initialize file cache and warm versions cache at startup
 const fileCache = getFileCache();

--- a/backend/src/startup.ts
+++ b/backend/src/startup.ts
@@ -1,0 +1,45 @@
+import { existsSync } from "node:fs";
+import { getConfig } from "./config.js";
+import { isCompilerInstalled } from "./utils.js";
+
+export interface StartupCheckResult {
+  ok: boolean;
+  errors: string[];
+}
+
+/**
+ * Validates that critical runtime dependencies are available before the
+ * server starts accepting traffic. Returns a result indicating success
+ * or failure with descriptive error messages.
+ */
+export async function validateStartup(): Promise<StartupCheckResult> {
+  const config = getConfig();
+  const errors: string[] = [];
+
+  // Check Compact CLI availability
+  const cliAvailable = await isCompilerInstalled();
+  if (!cliAvailable) {
+    errors.push(
+      `Compact CLI not found at "${config.compactCliPath}". ` +
+        "Ensure the Compact CLI is installed and COMPACT_CLI_PATH is set correctly.",
+    );
+  }
+
+  // Check OZ contracts path
+  if (!existsSync(config.ozContractsPath)) {
+    errors.push(
+      `OpenZeppelin contracts not found at "${config.ozContractsPath}". ` +
+        "Set OZ_CONTRACTS_PATH to the correct location.",
+    );
+  }
+
+  // Check OZ simulator path
+  if (!existsSync(config.ozSimulatorPath)) {
+    errors.push(
+      `OpenZeppelin simulator not found at "${config.ozSimulatorPath}". ` +
+        "Set OZ_SIMULATOR_PATH to the correct location.",
+    );
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/test/startup.test.ts
+++ b/test/startup.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../backend/src/utils.js", () => ({
+  isCompilerInstalled: vi.fn(),
+}));
+
+vi.mock("../backend/src/config.js", () => ({
+  getConfig: vi.fn(() => ({
+    compactCliPath: "compact",
+    ozContractsPath: "/opt/oz-compact/contracts/src",
+    ozSimulatorPath: "/opt/oz-compact/packages/simulator",
+  })),
+  resetConfig: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+import { existsSync } from "node:fs";
+import { isCompilerInstalled } from "../backend/src/utils.js";
+import { validateStartup } from "../backend/src/startup.js";
+
+const mockIsCompilerInstalled = isCompilerInstalled as ReturnType<typeof vi.fn>;
+const mockExistsSync = existsSync as ReturnType<typeof vi.fn>;
+
+describe("validateStartup", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns ok when all dependencies are available", async () => {
+    mockIsCompilerInstalled.mockResolvedValue(true);
+    mockExistsSync.mockReturnValue(true);
+
+    const result = await validateStartup();
+
+    expect(result.ok).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it("reports error when Compact CLI is not installed", async () => {
+    mockIsCompilerInstalled.mockResolvedValue(false);
+    mockExistsSync.mockReturnValue(true);
+
+    const result = await validateStartup();
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("Compact CLI not found");
+    expect(result.errors[0]).toContain("compact");
+  });
+
+  it("reports error when OZ contracts path is missing", async () => {
+    mockIsCompilerInstalled.mockResolvedValue(true);
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.includes("contracts")) return false;
+      return true;
+    });
+
+    const result = await validateStartup();
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("OpenZeppelin contracts not found"))).toBe(true);
+  });
+
+  it("reports error when OZ simulator path is missing", async () => {
+    mockIsCompilerInstalled.mockResolvedValue(true);
+    mockExistsSync.mockImplementation((p: string) => {
+      if (p.includes("simulator")) return false;
+      return true;
+    });
+
+    const result = await validateStartup();
+
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes("OpenZeppelin simulator not found"))).toBe(true);
+  });
+
+  it("reports multiple errors when all dependencies are missing", async () => {
+    mockIsCompilerInstalled.mockResolvedValue(false);
+    mockExistsSync.mockReturnValue(false);
+
+    const result = await validateStartup();
+
+    expect(result.ok).toBe(false);
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors[0]).toContain("Compact CLI");
+    expect(result.errors[1]).toContain("contracts");
+    expect(result.errors[2]).toContain("simulator");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `validateStartup()` in new `backend/src/startup.ts` that checks Compact CLI, OZ contracts path, and OZ simulator path before serving traffic
- Exits with code 1 and clear error messages if any dependency is missing
- Error messages include the checked path and the relevant env var name
- Accumulates all errors (operators see all issues at once, not one at a time)

## Test plan

- [x] All deps available → `{ ok: true, errors: [] }`
- [x] CLI missing → reports "Compact CLI not found" with path and env var
- [x] OZ contracts missing → reports error with path
- [x] OZ simulator missing → reports error with path
- [x] All deps missing → reports 3 errors
- [x] Full test suite passes (348/348, 32 test files)
- [x] Lint, format, typecheck, audit all clean

Closes #40

Generated with [Claude Code](https://claude.com/claude-code)