### PR TITLE
Fix: add stale temp-directory sweeper under TEMP_DIR

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -16,6 +16,7 @@ import { simulateRoutes } from "./routes/simulate.js";
 import { proveRoutes } from "./routes/prove.js";
 import { createJsonBodyLimit, validateRequestBody } from "./middleware.js";
 import { validateStartup } from "./startup.js";
+import { sweepStaleTempDirs } from "./temp-sweeper.js";
 import { healthRoutes, warmVersionsCache } from "./routes/health.js";
 import { getFileCache } from "./cache.js";
 
@@ -97,6 +98,29 @@ if (!startupCheck.ok) {
   process.exit(1);
 }
 console.log("Startup validation passed");
+
+// Sweep stale temp directories at startup and periodically
+const SWEEP_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+sweepStaleTempDirs()
+  .then(({ swept, errors }) => {
+    if (swept > 0 || errors > 0) {
+      console.log(`Startup temp sweep: ${String(swept)} removed, ${String(errors)} errors`);
+    }
+  })
+  .catch((err: unknown) => {
+    console.warn("Failed to sweep temp directories:", err);
+  });
+setInterval(() => {
+  sweepStaleTempDirs()
+    .then(({ swept, errors }) => {
+      if (swept > 0 || errors > 0) {
+        console.log(`Periodic temp sweep: ${String(swept)} removed, ${String(errors)} errors`);
+      }
+    })
+    .catch((err: unknown) => {
+      console.warn("Periodic temp sweep failed:", err);
+    });
+}, SWEEP_INTERVAL_MS).unref();
 
 // Initialize file cache and warm versions cache at startup
 const fileCache = getFileCache();

--- a/backend/src/temp-sweeper.ts
+++ b/backend/src/temp-sweeper.ts
@@ -1,0 +1,65 @@
+import { readdir, stat, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { getConfig } from "./config.js";
+
+/** Default age threshold: 1 hour in milliseconds */
+const DEFAULT_MAX_AGE_MS = 60 * 60 * 1000;
+
+/** Directories matching these prefixes are workspace session dirs eligible for sweeping. */
+const SESSION_DIR_PATTERNS = [
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/, // UUID (compiler, archive)
+  /^fmt-/, // formatter
+  /^sim-/, // simulator
+];
+
+function isSessionDir(name: string): boolean {
+  return SESSION_DIR_PATTERNS.some((pattern) => pattern.test(name));
+}
+
+export interface SweepResult {
+  swept: number;
+  errors: number;
+}
+
+/**
+ * Scans TEMP_DIR for session directories older than maxAgeMs and removes them.
+ * Only targets directories matching known session prefixes (UUID, fmt-, sim-).
+ * Skips non-session directories like compact-versions.
+ */
+export async function sweepStaleTempDirs(
+  maxAgeMs: number = DEFAULT_MAX_AGE_MS,
+): Promise<SweepResult> {
+  const config = getConfig();
+  const tempDir = config.tempDir;
+  const now = Date.now();
+  let swept = 0;
+  let errors = 0;
+
+  let entries: string[];
+  try {
+    entries = await readdir(tempDir);
+  } catch {
+    // TEMP_DIR doesn't exist yet — nothing to sweep
+    return { swept: 0, errors: 0 };
+  }
+
+  for (const entry of entries) {
+    if (!isSessionDir(entry)) continue;
+
+    const fullPath = join(tempDir, entry);
+    try {
+      const stats = await stat(fullPath);
+      if (!stats.isDirectory()) continue;
+
+      const ageMs = now - stats.mtimeMs;
+      if (ageMs > maxAgeMs) {
+        await rm(fullPath, { recursive: true, force: true });
+        swept++;
+      }
+    } catch {
+      errors++;
+    }
+  }
+
+  return { swept, errors };
+}

--- a/test/temp-sweeper.test.ts
+++ b/test/temp-sweeper.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, existsSync, utimesSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("../backend/src/config.js", () => ({
+  getConfig: vi.fn(),
+  resetConfig: vi.fn(),
+}));
+
+import { getConfig } from "../backend/src/config.js";
+import { sweepStaleTempDirs } from "../backend/src/temp-sweeper.js";
+
+const mockGetConfig = getConfig as ReturnType<typeof vi.fn>;
+
+describe("sweepStaleTempDirs", () => {
+  let testTempDir: string;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    testTempDir = mkdtempSync(join(tmpdir(), "sweep-test-"));
+    mockGetConfig.mockReturnValue({ tempDir: testTempDir });
+  });
+
+  afterEach(() => {
+    rmSync(testTempDir, { recursive: true, force: true });
+  });
+
+  function createDir(name: string, ageMs: number = 0): string {
+    const dir = join(testTempDir, name);
+    mkdirSync(dir, { recursive: true });
+    if (ageMs > 0) {
+      const past = new Date(Date.now() - ageMs);
+      utimesSync(dir, past, past);
+    }
+    return dir;
+  }
+
+  it("removes old UUID session dirs (compiler/archive pattern)", async () => {
+    const oldDir = createDir("a1b2c3d4-e5f6-7890-abcd-ef1234567890", 2 * 60 * 60 * 1000);
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000); // 1 hour threshold
+
+    expect(result.swept).toBe(1);
+    expect(result.errors).toBe(0);
+    expect(existsSync(oldDir)).toBe(false);
+  });
+
+  it("removes old fmt- dirs (formatter pattern)", async () => {
+    const oldDir = createDir("fmt-a1b2c3d4-e5f6-7890-abcd-ef1234567890", 2 * 60 * 60 * 1000);
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000);
+
+    expect(result.swept).toBe(1);
+    expect(existsSync(oldDir)).toBe(false);
+  });
+
+  it("removes old sim- dirs (simulator pattern)", async () => {
+    const oldDir = createDir("sim-a1b2c3d4-e5f6-7890-abcd-ef1234567890", 2 * 60 * 60 * 1000);
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000);
+
+    expect(result.swept).toBe(1);
+    expect(existsSync(oldDir)).toBe(false);
+  });
+
+  it("does NOT remove recent session dirs", async () => {
+    const recentDir = createDir("a1b2c3d4-e5f6-7890-abcd-ef1234567890"); // just created
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000);
+
+    expect(result.swept).toBe(0);
+    expect(existsSync(recentDir)).toBe(true);
+  });
+
+  it("does NOT remove non-session dirs like compact-versions", async () => {
+    const versionsDir = createDir("compact-versions", 2 * 60 * 60 * 1000);
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000);
+
+    expect(result.swept).toBe(0);
+    expect(existsSync(versionsDir)).toBe(true);
+  });
+
+  it("does NOT remove arbitrary named dirs", async () => {
+    const otherDir = createDir("some-other-thing", 2 * 60 * 60 * 1000);
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000);
+
+    expect(result.swept).toBe(0);
+    expect(existsSync(otherDir)).toBe(true);
+  });
+
+  it("skips files (not directories)", async () => {
+    const filePath = join(testTempDir, "a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+    writeFileSync(filePath, "not a dir");
+    const past = new Date(Date.now() - 2 * 60 * 60 * 1000);
+    utimesSync(filePath, past, past);
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000);
+
+    expect(result.swept).toBe(0);
+  });
+
+  it("returns zeros when TEMP_DIR does not exist", async () => {
+    mockGetConfig.mockReturnValue({ tempDir: "/nonexistent/path/that/does/not/exist" });
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000);
+
+    expect(result.swept).toBe(0);
+    expect(result.errors).toBe(0);
+  });
+
+  it("sweeps multiple old dirs in a single pass", async () => {
+    createDir("a1b2c3d4-e5f6-7890-abcd-ef1234567890", 2 * 60 * 60 * 1000);
+    createDir("fmt-b2c3d4e5-f6a7-8901-bcde-f12345678901", 2 * 60 * 60 * 1000);
+    createDir("sim-c3d4e5f6-a7b8-9012-cdef-123456789012", 2 * 60 * 60 * 1000);
+    createDir("compact-versions", 2 * 60 * 60 * 1000); // should NOT be swept
+
+    const result = await sweepStaleTempDirs(60 * 60 * 1000);
+
+    expect(result.swept).toBe(3);
+    expect(result.errors).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `sweepStaleTempDirs()` in new `backend/src/temp-sweeper.ts` that scans TEMP_DIR for orphaned session directories older than 1 hour
- Targets only known session dir patterns: UUIDs (compiler/archive), `fmt-*` (formatter), `sim-*` (simulator)
- Skips non-session directories like `compact-versions`
- Runs at startup and every 30 minutes via `.unref()`'d interval
- Logs sweep results (count removed, errors) at startup and periodically
- Safety net for crash scenarios where finally-block cleanup doesn't run

## Test plan

- [x] Removes old UUID session dirs (compiler/archive pattern)
- [x] Removes old `fmt-*` dirs (formatter pattern)
- [x] Removes old `sim-*` dirs (simulator pattern)
- [x] Skips recent session dirs (under age threshold)
- [x] Skips `compact-versions` and arbitrary non-session dirs
- [x] Skips files (not directories)
- [x] Handles missing TEMP_DIR gracefully
- [x] Sweeps multiple old dirs in a single pass
- [x] Full test suite passes (352/352, 32 test files)
- [x] Lint, format, typecheck, audit all clean

Closes #35

Generated with [Claude Code](https://claude.com/claude-code)