### PR TITLE
Docs: fix and complete environment variable documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,31 @@
-# .env.example
+# Server
 PORT=8080
 COMPACT_CLI_PATH=compact
 DEFAULT_COMPILER_VERSION=latest
-CACHE_ENABLED=true
-CACHE_MAX_SIZE=1000
-CACHE_TTL=3600000
+TEMP_DIR=/tmp/compact-playground
+COMPILE_TIMEOUT=30000
+
+# Rate limiting
 RATE_LIMIT=20
 RATE_WINDOW=60000
+ARCHIVE_RATE_LIMIT=10
+ARCHIVE_RATE_WINDOW=60000
+
+# Cache
+CACHE_ENABLED=true
+CACHE_DIR=/data/cache
+CACHE_MAX_DISK_MB=800
+CACHE_MAX_ENTRIES=50000
+CACHE_TTL=2592000000
+
+# Request limits
+MAX_CODE_SIZE=102400
+MAX_VERSIONS_PER_REQUEST=10
+
+# Proxy trust (set to true when behind the corresponding proxy)
+TRUST_PROXY=false
+TRUST_CLOUDFLARE=false
+
+# OpenZeppelin Compact paths (set in Dockerfile, override for local dev)
+# OZ_CONTRACTS_PATH=/opt/oz-compact/contracts/src
+# OZ_SIMULATOR_PATH=/opt/oz-compact/packages/simulator

--- a/README.md
+++ b/README.md
@@ -318,13 +318,19 @@ All settings are controlled via environment variables:
 | `COMPILE_TIMEOUT` | `30000` | Compilation timeout in ms |
 | `RATE_LIMIT` | `20` | Max requests per window per IP |
 | `RATE_WINDOW` | `60000` | Rate limit window in ms |
-| `CACHE_ENABLED` | `true` | Enable compilation cache |
-| `CACHE_MAX_SIZE` | `1000` | Max cache entries |
-| `CACHE_TTL` | `3600000` | Cache TTL in ms (1 hour) |
+| `ARCHIVE_RATE_LIMIT` | `10` | Max archive compile requests per IP per window |
+| `ARCHIVE_RATE_WINDOW` | `60000` | Archive rate limit window in ms |
+| `CACHE_ENABLED` | `true` | Enable file-based result caching |
+| `CACHE_DIR` | `/data/cache` | Persistent cache directory |
+| `CACHE_MAX_DISK_MB` | `800` | Max cache disk usage in MB |
+| `CACHE_MAX_ENTRIES` | `50000` | Max cached entries |
+| `CACHE_TTL` | `2592000000` | Cache entry TTL in ms (30 days) |
 | `MAX_CODE_SIZE` | `102400` | Max code size in bytes (100 KB) |
 | `MAX_VERSIONS_PER_REQUEST` | `10` | Max versions in a multi-version request |
 | `TRUST_PROXY` | `false` | Trust `X-Forwarded-For` / `X-Real-IP` headers for client IP |
 | `TRUST_CLOUDFLARE` | `false` | Trust `CF-Connecting-IP` header for client IP |
+| `OZ_CONTRACTS_PATH` | `/opt/oz-compact/contracts/src` | Path to OpenZeppelin Compact contracts |
+| `OZ_SIMULATOR_PATH` | `/opt/oz-compact/packages/simulator` | Path to OZ simulator package |
 
 > **Learn Compact:** Set `DEFAULT_COMPILER_VERSION=0.26.0` to pin the compiler to match `pragma language_version >= 0.16 && <= 0.18` used in the tutorial contracts.
 


### PR DESCRIPTION
## Summary

- Rewrites `.env.example` to mirror all 20 env vars from `config.ts` with correct defaults and section grouping
- Removes phantom `CACHE_MAX_SIZE` (never consumed by the app)
- Fixes `CACHE_TTL` from `3600000` (1 hour) to `2592000000` (30 days)
- Adds missing vars to `README.md`: `CACHE_DIR`, `CACHE_MAX_DISK_MB`, `CACHE_MAX_ENTRIES`, `ARCHIVE_RATE_LIMIT`, `ARCHIVE_RATE_WINDOW`, `OZ_CONTRACTS_PATH`, `OZ_SIMULATOR_PATH`
- All defaults now match across `config.ts`, `.env.example`, `README.md`, and `backend/README.md`

## Test plan

- [x] Every env var in `getConfig()` is documented in `.env.example`
- [x] Every env var in `getConfig()` is in the README.md table
- [x] All defaults match `config.ts` source of truth
- [x] `backend/README.md` (already correct) is consistent with updated files
- [x] Full test suite passes (343/343)
- [x] All pre-push checks clean

Closes #38

Generated with [Claude Code](https://claude.com/claude-code)