### PR TITLE
Feat: salt cached-response hashes with a server-side secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ CACHE_DIR=/data/cache
 CACHE_MAX_DISK_MB=800
 CACHE_MAX_ENTRIES=50000
 CACHE_TTL=2592000000
+# Server-side salt mixed into cache key hashes. Rotating this invalidates all cached lookups.
+# CACHE_KEY_SALT=your-secret-salt-here
 
 # Request limits
 MAX_CODE_SIZE=102400

--- a/backend/src/cache.ts
+++ b/backend/src/cache.ts
@@ -14,10 +14,10 @@ export function generateArchiveCacheKey(
   version: string,
   options: Record<string, unknown>,
 ): string {
-  return createHash("sha256")
-    .update(archiveBuffer)
-    .update(JSON.stringify({ version, options }))
-    .digest("hex");
+  const { cacheKeySalt } = getConfig();
+  const hash = createHash("sha256");
+  if (cacheKeySalt) hash.update(cacheKeySalt);
+  return hash.update(archiveBuffer).update(JSON.stringify({ version, options })).digest("hex");
 }
 
 /** Generate a deterministic cache key from code + version + options */
@@ -26,9 +26,12 @@ export function generateCacheKey(
   compilerVersion: string,
   options: Record<string, unknown>,
 ): string {
+  const { cacheKeySalt } = getConfig();
   const normalized = normalizeForCacheKey(code);
   const payload = JSON.stringify({ code: normalized, version: compilerVersion, options });
-  return createHash("sha256").update(payload).digest("hex");
+  const hash = createHash("sha256");
+  if (cacheKeySalt) hash.update(cacheKeySalt);
+  return hash.update(payload).digest("hex");
 }
 
 interface IndexEntry {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -11,6 +11,7 @@ export interface Config {
   cacheMaxDiskMb: number;
   cacheMaxEntries: number;
   cacheTtl: number;
+  cacheKeySalt: string;
   maxVersionsPerRequest: number;
   maxCodeSize: number;
   maxJsonBodySize: number;
@@ -40,6 +41,7 @@ export function getConfig(): Config {
     cacheMaxDiskMb: parseInt(process.env.CACHE_MAX_DISK_MB || "800", 10),
     cacheMaxEntries: parseInt(process.env.CACHE_MAX_ENTRIES || "50000", 10),
     cacheTtl: parseInt(process.env.CACHE_TTL || "2592000000", 10), // 30 days
+    cacheKeySalt: process.env.CACHE_KEY_SALT || "",
     maxVersionsPerRequest: parseInt(process.env.MAX_VERSIONS_PER_REQUEST || "3", 10),
     maxCodeSize: parseInt(process.env.MAX_CODE_SIZE || String(100 * 1024), 10),
     maxJsonBodySize: parseInt(process.env.MAX_JSON_BODY_SIZE || String(512 * 1024), 10),

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -131,6 +131,13 @@ setInterval(() => {
     });
 }, SWEEP_INTERVAL_MS).unref();
 
+if (!getConfig().cacheKeySalt) {
+  console.warn(
+    "WARNING: CACHE_KEY_SALT is not set. Cache keys are deterministic and " +
+      "cached responses may be retrievable by anyone who can reconstruct inputs.",
+  );
+}
+
 // Initialize file cache and warm versions cache at startup
 const fileCache = getFileCache();
 if (fileCache) {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -8,6 +8,7 @@ import {
   generateCacheKey,
   generateArchiveCacheKey,
 } from "../backend/src/cache.js";
+import { resetConfig } from "../backend/src/config.js";
 
 describe("FileCache", () => {
   let tempDir: string;
@@ -210,5 +211,66 @@ describe("generateArchiveCacheKey", () => {
     const a = generateArchiveCacheKey(archive, "0.26.0", { optimize: true });
     const b = generateArchiveCacheKey(archive, "0.26.0", { optimize: false });
     expect(a).not.toBe(b);
+  });
+});
+
+describe("CACHE_KEY_SALT", () => {
+  beforeEach(() => {
+    delete process.env.CACHE_KEY_SALT;
+    resetConfig();
+  });
+
+  afterEach(() => {
+    delete process.env.CACHE_KEY_SALT;
+    resetConfig();
+  });
+
+  it("generateCacheKey produces different keys with different salts", () => {
+    process.env.CACHE_KEY_SALT = "salt-a";
+    resetConfig();
+    const a = generateCacheKey("code", "0.26.0", {});
+
+    process.env.CACHE_KEY_SALT = "salt-b";
+    resetConfig();
+    const b = generateCacheKey("code", "0.26.0", {});
+
+    expect(a).not.toBe(b);
+  });
+
+  it("generateArchiveCacheKey produces different keys with different salts", () => {
+    const archive = Buffer.from("archive content");
+
+    process.env.CACHE_KEY_SALT = "salt-a";
+    resetConfig();
+    const a = generateArchiveCacheKey(archive, "0.26.0", {});
+
+    process.env.CACHE_KEY_SALT = "salt-b";
+    resetConfig();
+    const b = generateArchiveCacheKey(archive, "0.26.0", {});
+
+    expect(a).not.toBe(b);
+  });
+
+  it("unsalted keys match the previous (no salt) behavior", () => {
+    // No CACHE_KEY_SALT set — default empty string
+    resetConfig();
+    const unsalted = generateCacheKey("code", "0.26.0", {});
+
+    // Same inputs, still no salt
+    resetConfig();
+    const unsalted2 = generateCacheKey("code", "0.26.0", {});
+
+    expect(unsalted).toBe(unsalted2);
+  });
+
+  it("salted key differs from unsalted key", () => {
+    resetConfig();
+    const unsalted = generateCacheKey("code", "0.26.0", {});
+
+    process.env.CACHE_KEY_SALT = "my-secret";
+    resetConfig();
+    const salted = generateCacheKey("code", "0.26.0", {});
+
+    expect(salted).not.toBe(unsalted);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `CACHE_KEY_SALT` env var mixed into both `generateCacheKey()` and `generateArchiveCacheKey()`
- When set, makes cache keys unpredictable — prevents cache key derivation from known inputs
- Logs a startup warning when `CACHE_KEY_SALT` is not configured
- Backward compatible: empty/unset salt preserves previous behavior
- Rotating the salt invalidates all existing cache lookups

## Test plan

- [x] Different salts produce different keys (both functions)
- [x] Unsalted keys remain deterministic (backward compatible)
- [x] Salted key differs from unsalted key
- [x] All 22 existing cache tests still pass unchanged
- [x] Full test suite passes (347/347)
- [x] Lint, format, typecheck, audit all clean

Closes #37

Generated with [Claude Code](https://claude.com/claude-code)