### PR TITLE
Feat: remove source maps and test artifacts from the production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM node:25-slim AS builder
 
 WORKDIR /app
 
-# Copy package files
+# Copy package files and build configs
 COPY package*.json ./
-COPY tsconfig.json ./
+COPY tsconfig.json tsconfig.build.json ./
 
 # Install all dependencies (including dev for building)
 RUN npm ci
@@ -13,8 +13,8 @@ RUN npm ci
 # Copy source code
 COPY backend/ ./backend/
 
-# Build TypeScript
-RUN npm run build
+# Build TypeScript for production (no source maps, no declarations, no tests)
+RUN npx tsc -p tsconfig.build.json
 
 # OZ Compact dependencies stage — clone in a lightweight image, keep git out of production
 FROM alpine/git AS oz-clone

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "declarationMap": false,
+    "sourceMap": false
+  },
+  "include": ["backend/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `tsconfig.build.json` for production builds: disables `declaration`, `declarationMap`, `sourceMap`; includes only `backend/**/*.ts`
- Docker builder stage uses the production config instead of the base tsconfig
- Production build emits 40 `.js` files vs. 288 files (including `.d.ts`, `.map`, and test artifacts) — ~86% reduction
- Local dev/test workflows unaffected — they still use `tsconfig.json` with full tooling

## Test plan

- [x] `npx tsc -p tsconfig.build.json` succeeds with zero errors
- [x] Production build emits only `.js` files (no `.map`, `.d.ts`, `.d.ts.map`)
- [x] No `dist/test/` directory in production output
- [x] `npm run typecheck` (base tsconfig) still passes
- [x] Full test suite passes (343/343)
- [x] All pre-push checks clean (lint, format, typecheck, audit)

Closes #39

Generated with [Claude Code](https://claude.com/claude-code)