### PR TITLE
Feat: align CI compiler coverage with the shipped runtime matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
           compact update 0.30.0
           compact update 0.29.0
           compact update 0.28.0
+          compact update 0.26.0
+          compact update 0.25.0
+          compact update 0.24.0
+          compact update 0.23.0
+          compact update 0.22.0
       - run: npm ci
       - run: npm run test:run
 


### PR DESCRIPTION
## Summary

- Adds 5 missing compiler versions to the CI test job: 0.26.0, 0.25.0, 0.24.0, 0.23.0, 0.22.0
- CI now installs the same 8 versions (0.22.0–0.30.0) shipped in the Docker production image
- Prevents version-specific regressions in older compilers from reaching production untested

## Test plan

- [x] CI version list matches Dockerfile version list exactly (8 versions)
- [x] Version order consistent (newest first) in both files
- [x] Full test suite passes (343/343)
- [x] All pre-push checks clean (lint, format, typecheck, audit)

Closes #41

Generated with [Claude Code](https://claude.com/claude-code)