### PR TITLE
Feat: add graceful shutdown handling for container stop events

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import { proveRoutes } from "./routes/prove.js";
 import { createJsonBodyLimit, validateRequestBody } from "./middleware.js";
 import { validateStartup } from "./startup.js";
 import { sweepStaleTempDirs } from "./temp-sweeper.js";
+import { isShuttingDown, registerShutdownHandlers } from "./shutdown.js";
 import { healthRoutes, warmVersionsCache } from "./routes/health.js";
 import { getFileCache } from "./cache.js";
 
@@ -36,6 +37,14 @@ app.use(
     allowHeaders: ["Content-Type"],
   }),
 );
+
+// Reject new requests during shutdown (before any body parsing)
+app.use("*", async (c, next) => {
+  if (isShuttingDown()) {
+    return c.json({ success: false, error: "Service is shutting down" }, 503);
+  }
+  return next();
+});
 
 app.use("*", createJsonBodyLimit());
 app.use("*", validateRequestBody);
@@ -143,9 +152,11 @@ warmVersionsCache()
     console.warn("Failed to warm versions cache:", err);
   });
 
-serve({
+const server = serve({
   fetch: app.fetch,
   port,
 });
+
+registerShutdownHandlers(server);
 
 console.log(`Server running at http://localhost:${String(port)}`);

--- a/backend/src/shutdown.ts
+++ b/backend/src/shutdown.ts
@@ -1,0 +1,47 @@
+import type { Server } from "node:net";
+
+const SHUTDOWN_TIMEOUT_MS = 10_000; // 10 seconds
+
+let shuttingDown = false;
+
+export function isShuttingDown(): boolean {
+  return shuttingDown;
+}
+
+/** Reset shutdown state (for testing only) */
+export function resetShutdownState(): void {
+  shuttingDown = false;
+}
+
+/**
+ * Initiates a graceful shutdown: closes the server, waits for connections
+ * to drain, and exits. Safe to call multiple times (only the first call acts).
+ */
+export function initiateShutdown(server: Server, signal: string): void {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`${signal} received, shutting down gracefully...`);
+
+  server.close(() => {
+    console.log("All connections closed, exiting");
+    process.exit(0);
+  });
+
+  // Force exit if connections don't drain in time
+  setTimeout(() => {
+    console.warn(`Shutdown timed out after ${String(SHUTDOWN_TIMEOUT_MS)}ms, forcing exit`);
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+}
+
+/**
+ * Registers SIGTERM and SIGINT handlers that trigger graceful shutdown.
+ */
+export function registerShutdownHandlers(server: Server): void {
+  process.on("SIGTERM", () => {
+    initiateShutdown(server, "SIGTERM");
+  });
+  process.on("SIGINT", () => {
+    initiateShutdown(server, "SIGINT");
+  });
+}

--- a/test/shutdown.test.ts
+++ b/test/shutdown.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createServer } from "node:http";
+import { isShuttingDown, initiateShutdown, resetShutdownState } from "../backend/src/shutdown.js";
+
+describe("shutdown", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    resetShutdownState();
+  });
+
+  it("isShuttingDown returns false initially", () => {
+    expect(isShuttingDown()).toBe(false);
+  });
+
+  it("initiateShutdown closes the server and exits with 0", () => {
+    const server = createServer();
+    const closeSpy = vi.spyOn(server, "close").mockImplementation(function (cb) {
+      if (cb) (cb as () => void)();
+      return server;
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    initiateShutdown(server, "SIGTERM");
+
+    expect(isShuttingDown()).toBe(true);
+    expect(closeSpy).toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    server.close();
+  });
+
+  it("ignores duplicate shutdown calls", () => {
+    const server = createServer();
+    let closeCallCount = 0;
+    vi.spyOn(server, "close").mockImplementation(function (cb) {
+      closeCallCount++;
+      if (cb) (cb as () => void)();
+      return server;
+    });
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    initiateShutdown(server, "SIGTERM");
+    initiateShutdown(server, "SIGINT"); // second call should be ignored
+
+    expect(closeCallCount).toBe(1);
+
+    server.close();
+  });
+
+  it("isShuttingDown returns true after shutdown initiated", () => {
+    const server = createServer();
+    vi.spyOn(server, "close").mockImplementation(function (cb) {
+      if (cb) (cb as () => void)();
+      return server;
+    });
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+
+    expect(isShuttingDown()).toBe(false);
+    initiateShutdown(server, "SIGTERM");
+    expect(isShuttingDown()).toBe(true);
+
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `backend/src/shutdown.ts` with `initiateShutdown()` and `registerShutdownHandlers()` for SIGTERM/SIGINT
- Shutdown sequence: reject new requests (503) → close server → drain connections → exit(0)
- 10-second timeout forces exit(1) if connections don't drain
- 503 middleware placed before body parsing to minimize wasted work during shutdown
- Uses `net.Server` type for compatibility with all Hono server types

## Test plan

- [x] `isShuttingDown()` returns false initially
- [x] `initiateShutdown()` closes server and exits with code 0
- [x] Duplicate shutdown signals are ignored (idempotent)
- [x] State transitions correctly (`isShuttingDown()` → true after initiate)
- [x] Full test suite passes (347/347, 32 test files)
- [x] Lint, format, typecheck, audit all clean

Closes #34

Generated with [Claude Code](https://claude.com/claude-code)