### PR TITLE
Fix: support X-Client-ID header for per-instance rate limiting

### DIFF
--- a/backend/src/rate-limit.ts
+++ b/backend/src/rate-limit.ts
@@ -85,15 +85,21 @@ function getRuntimeIp(c: Context): string | null {
 }
 
 /**
- * Extracts client IP from request based on trust configuration.
+ * Extracts a client identity for rate limiting.
  *
  * Precedence:
- * 1. TRUST_CLOUDFLARE=true → CF-Connecting-IP (set by Cloudflare, not spoofable)
- * 2. TRUST_PROXY=true → x-forwarded-for / x-real-ip (only safe behind a trusted reverse proxy)
- * 3. Runtime/platform-provided client IP (e.g. Node socket remoteAddress)
- * 4. "unknown" (safe final fallback)
+ * 1. X-Client-ID header (opaque per-instance ID sent by MCP/API clients)
+ * 2. TRUST_CLOUDFLARE=true → CF-Connecting-IP (set by Cloudflare, not spoofable)
+ * 3. TRUST_PROXY=true → x-forwarded-for / x-real-ip (only safe behind a trusted reverse proxy)
+ * 4. Runtime/platform-provided client IP (e.g. Node socket remoteAddress)
+ * 5. "unknown" (safe final fallback)
  */
 export function getClientIp(c: Context): string {
+  // X-Client-ID allows proxied clients (e.g. MCP servers) to get
+  // per-instance rate limit buckets instead of sharing one IP bucket.
+  const clientId = c.req.header("x-client-id");
+  if (clientId && clientId.trim()) return `client:${clientId.trim()}`;
+
   const config = getConfig();
 
   if (config.trustCloudflare) {

--- a/test/rate-limit.test.ts
+++ b/test/rate-limit.test.ts
@@ -19,6 +19,38 @@ describe("getClientIp", () => {
     resetConfig();
   });
 
+  describe("with X-Client-ID header", () => {
+    it("uses X-Client-ID as rate limit key with client: prefix", () => {
+      const c = mockContext({ "x-client-id": "f47ac10b-58cc-4372-a567-0e02b2c3d479" });
+      expect(getClientIp(c)).toBe("client:f47ac10b-58cc-4372-a567-0e02b2c3d479");
+    });
+
+    it("takes precedence over all other headers", () => {
+      process.env.TRUST_PROXY = "true";
+      process.env.TRUST_CLOUDFLARE = "true";
+      resetConfig();
+      const c = mockContext({
+        "x-client-id": "my-client",
+        "cf-connecting-ip": "1.1.1.1",
+        "x-forwarded-for": "2.2.2.2",
+      });
+      expect(getClientIp(c)).toBe("client:my-client");
+    });
+
+    it("trims whitespace", () => {
+      const c = mockContext({ "x-client-id": "  my-client  " });
+      expect(getClientIp(c)).toBe("client:my-client");
+    });
+
+    it("ignores empty X-Client-ID and falls through", () => {
+      const c = mockContext(
+        { "x-client-id": "  " },
+        { incoming: { socket: { remoteAddress: "10.0.0.1" } } },
+      );
+      expect(getClientIp(c)).toBe("10.0.0.1");
+    });
+  });
+
   describe("with TRUST_PROXY=true", () => {
     beforeEach(() => {
       process.env.TRUST_PROXY = "true";


### PR DESCRIPTION
## Summary

Adds `X-Client-ID` header support to the rate limiter so proxied clients (like the MCP server) get per-instance rate limit buckets instead of sharing one IP bucket.

## Problem

The midnight-mcp server proxies all user requests through a Cloudflare Worker, so every request hits the playground from the same IP. All MCP users share a single 20 req/60s bucket and get rate-limited as adoption grows.

## Changes

- `backend/src/rate-limit.ts` — `getClientIp()` now checks `X-Client-ID` header first (highest priority). Values are prefixed with `client:` to avoid key collisions with IP addresses.
- `test/rate-limit.test.ts` — 4 new tests: basic usage, precedence over other headers, whitespace trimming, empty header fallthrough.

## Precedence order

1. `X-Client-ID` header → `client:<value>`
2. `CF-Connecting-IP` (if `TRUST_CLOUDFLARE=true`)
3. `X-Forwarded-For` / `X-Real-IP` (if `TRUST_PROXY=true`)
4. Socket `remoteAddress`
5. `"unknown"`

Companion issue for the MCP side: devrelaicom/midnight-mcp#64

Generated with [Claude Code](https://claude.com/claude-code)